### PR TITLE
added pawn promotion feature + updated readme

### DIFF
--- a/Board.h
+++ b/Board.h
@@ -12,6 +12,7 @@ class Board {
 public:
   Board();
   bool move(Pos src, Pos dst);             // applies move if legal
+  bool move(Pos src, Pos dst, char promotionPiece); // applies move with promotion if legal
   void draw(std::ostream& os) const;       // ASCII draw
   std::shared_ptr<Piece> pieceAt(Pos p) const;
   bool isInCheck(Colour c) const;
@@ -21,6 +22,7 @@ private:
   std::vector<std::vector<std::shared_ptr<Piece>>> grid;
   Colour currentTurn;
   bool simulateMove(Pos src, Pos dst, Colour playerColour) const; // simulate move to check if it leaves player in check
+  std::shared_ptr<Piece> createPromotedPiece(char pieceType, Colour c); // create a piece for promotion
 };
 
 #endif // BOARD_H 

--- a/GameController.cc
+++ b/GameController.cc
@@ -42,8 +42,8 @@ bool GameController::processCommand(const std::string& cmd) {
       return true;
     }
     
-    std::string src_str, dst_str;
-    iss >> src_str >> dst_str;
+    std::string src_str, dst_str, promotion_str;
+    iss >> src_str >> dst_str >> promotion_str;
     
     Pos src = parsePos(src_str);
     Pos dst = parsePos(dst_str);
@@ -53,12 +53,28 @@ bool GameController::processCommand(const std::string& cmd) {
       return true;
     }
     
-    if (board->move(src, dst)) {
+    bool moveSuccess = false;
+    
+    // Check if promotion piece is specified
+    if (!promotion_str.empty() && promotion_str.length() == 1) {
+      char promotionPiece = promotion_str[0];
+      moveSuccess = board->move(src, dst, promotionPiece);
+    } else {
+      moveSuccess = board->move(src, dst);
+    }
+    
+    if (moveSuccess) {
       board->draw(std::cout);
       
       // After a move, the current player is the one whose turn it is now
       // The piece at the destination belongs to the player who just moved
-      Colour previousPlayerColour = board->pieceAt(dst)->colour();
+      auto piece = board->pieceAt(dst);
+      if (!piece) {
+        // This shouldn't happen in a valid move, but let's be safe
+        return true;
+      }
+      
+      Colour previousPlayerColour = piece->colour();
       Colour currentPlayerColour = (previousPlayerColour == Colour::White) ? Colour::Black : Colour::White;
       
       // Check if the current player is in check

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A command-line chess game implemented in C++20 for CS246 Spring 2025.
 - Text-only UI with ASCII board representation
 - Human vs Human gameplay
 - Basic move legality for all six piece types
-- Pawn auto-promotion to Queen
+- Pawn promotion to Queen, Rook, Bishop, or Knight (if not promotion given, base case is Queen)
 - No castling or en-passant
 
 ## Supported Commands
 - `game human human` - Start a new game
 - `move <src> <dst>` - Move a piece (e.g., `move e2 e4`)
+- `move <src> <dst> <promotion>` - Move a pawn with promotion (e.g., `move e7 e8 Q`)
+  - Valid promotion pieces: Q (Queen), R (Rook), B (Bishop), N (Knight)
 - `resign` - Resign the current game
 - Ctrl-D to quit
 


### PR DESCRIPTION
### Add Pawn Promotion Feature

This PR implements pawn promotion functionality, allowing players to choose which piece type to promote their pawns to when they reach the opponent's back rank.

**Changes**

- Added support for specifying promotion piece type in move command (move e7 e8 Q)
- If no piece specified for promotion the pawn gets auto promoted to Queen
- Implemented promotion to Queen, Rook, Bishop, or Knight
- Updated Board class with new move method that handles promotion
- Enhanced GameController to parse promotion notation
- Updated README with new command syntax

**Testing**

- Tested by promoting pawns to different piece types and verifying correct behavior.