### PR TITLE
add setup mode feature

### DIFF
--- a/Board.cc
+++ b/Board.cc
@@ -737,4 +737,51 @@ bool Board::canCastle(Pos src, Pos dst) const {
 
 Colour Board::getCurrentTurn() const {
   return currentTurn;
+}
+
+void Board::placePiece(Pos pos, char pieceType, Colour colour) {
+  if (!isValidPos(pos)) return;
+  
+  std::shared_ptr<Piece> piece = nullptr;
+  
+  switch (toupper(pieceType)) {
+    case 'P': piece = std::make_shared<Pawn>(colour); break;
+    case 'N': piece = std::make_shared<Knight>(colour); break;
+    case 'B': piece = std::make_shared<Bishop>(colour); break;
+    case 'R': piece = std::make_shared<Rook>(colour); break;
+    case 'Q': piece = std::make_shared<Queen>(colour); break;
+    case 'K': piece = std::make_shared<King>(colour); break;
+    default: return;
+  }
+  
+  grid[pos.rank][pos.file] = piece;
+}
+
+void Board::removePiece(Pos pos) {
+  if (!isValidPos(pos)) return;
+  grid[pos.rank][pos.file] = nullptr;
+}
+
+void Board::setCurrentTurn(Colour c) {
+  currentTurn = c;
+}
+
+void Board::clearBoard() {
+  // Clear all pieces from the board
+  for (int rank = 0; rank < 8; ++rank) {
+    for (int file = 0; file < 8; ++file) {
+      grid[rank][file] = nullptr;
+    }
+  }
+  
+  // Reset castling flags
+  whiteKingMoved = false;
+  blackKingMoved = false;
+  whiteRookAMoved = false;
+  whiteRookHMoved = false;
+  blackRookAMoved = false;
+  blackRookHMoved = false;
+  
+  // Reset en passant tracking
+  lastPawnDoubleMove = {-1, -1};
 } 

--- a/Board.h
+++ b/Board.h
@@ -23,6 +23,12 @@ public:
   bool canCastle(Pos src, Pos dst) const;  // check if castling is legal
   Colour getCurrentTurn() const;           // get the current player's color
   
+  // Setup mode methods
+  void placePiece(Pos pos, char pieceType, Colour colour);  // place a piece during setup
+  void removePiece(Pos pos);                               // remove a piece during setup
+  void setCurrentTurn(Colour c);                           // set the current player's turn
+  void clearBoard();                                       // clear the board for setup mode
+  
   // Helper methods for King's legal moves
   bool hasKingMoved(Colour c) const;
   bool hasRookMoved(Colour c, bool kingSide) const;

--- a/GameController.cc
+++ b/GameController.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <sstream>
 
-GameController::GameController() : board{nullptr}, gameInProgress{false} {}
+GameController::GameController() : board{nullptr}, gameInProgress{false}, setupMode{false} {}
 
 Pos GameController::parsePos(const std::string& pos) {
   if (pos.length() != 2) return {-1, -1};
@@ -25,7 +25,21 @@ bool GameController::processCommand(const std::string& cmd) {
   std::string command;
   iss >> command;
   
-  if (command == "game") {
+  if (command == "setup") {
+    if (gameInProgress) {
+      std::cout << "Cannot enter setup mode while a game is in progress.\n";
+      return true;
+    }
+    
+    // Initialize a new empty board for setup
+    board = std::make_shared<Board>();
+    board->clearBoard();
+    setupMode = true;
+    std::cout << "Entering setup mode.\n";
+    board->draw(std::cout);
+    return true;
+  }
+  else if (command == "game") {
     std::string player1, player2;
     iss >> player1 >> player2;
     
@@ -151,12 +165,185 @@ bool GameController::processCommand(const std::string& cmd) {
   return true;
 }
 
+bool GameController::processSetupCommand(const std::string& cmd) {
+  std::istringstream iss(cmd);
+  std::string command;
+  iss >> command;
+  
+  if (command == "+") {
+    // Place a piece: + [piece] [position]
+    char pieceType;
+    std::string posStr;
+    iss >> pieceType >> posStr;
+    
+    if (pieceType == 0 || posStr.empty()) {
+      std::cout << "Invalid command format. Use '+ [piece] [position]'.\n";
+      return true;
+    }
+    
+    Pos pos = parsePos(posStr);
+    if (pos.file == -1) {
+      std::cout << "Invalid position.\n";
+      return true;
+    }
+    
+    // Determine piece color based on case
+    Colour colour = isupper(pieceType) ? Colour::White : Colour::Black;
+    
+    // Place the piece
+    board->placePiece(pos, pieceType, colour);
+    board->draw(std::cout);
+  } 
+  else if (command == "-") {
+    // Remove a piece: - [position]
+    std::string posStr;
+    iss >> posStr;
+    
+    if (posStr.empty()) {
+      std::cout << "Invalid command format. Use '- [position]'.\n";
+      return true;
+    }
+    
+    Pos pos = parsePos(posStr);
+    if (pos.file == -1) {
+      std::cout << "Invalid position.\n";
+      return true;
+    }
+    
+    // Remove the piece
+    board->removePiece(pos);
+    board->draw(std::cout);
+  }
+  else if (command == "=") {
+    // Set turn: = [color]
+    std::string colorStr;
+    iss >> colorStr;
+    
+    if (colorStr.empty()) {
+      std::cout << "Invalid command format. Use '= [color]'.\n";
+      return true;
+    }
+    
+    if (colorStr == "white") {
+      board->setCurrentTurn(Colour::White);
+      std::cout << "Set white to play next.\n";
+    } else if (colorStr == "black") {
+      board->setCurrentTurn(Colour::Black);
+      std::cout << "Set black to play next.\n";
+    } else {
+      std::cout << "Invalid color. Use 'white' or 'black'.\n";
+    }
+  }
+  else if (command == "done") {
+    // Exit setup mode
+    if (validateBoard()) {
+      setupMode = false;
+      std::cout << "Exiting setup mode. Board is valid.\n";
+      board->draw(std::cout);
+      gameInProgress = true;
+      
+      // Check for stalemate immediately after setup
+      Colour currentPlayerColour = board->getCurrentTurn();
+      if (board->isStalemate(currentPlayerColour)) {
+        std::cout << "Stalemate! The game is a draw.\n";
+        gameInProgress = false;
+      } else if (board->isInCheck(currentPlayerColour)) {
+        if (board->isCheckmate(currentPlayerColour)) {
+          std::cout << (currentPlayerColour == Colour::White ? "Black" : "White") << " wins!\n";
+          gameInProgress = false;
+        } else {
+          std::cout << "Check!\n";
+        }
+      }
+    } else {
+      std::cout << "Invalid board configuration. Cannot exit setup mode.\n";
+    }
+  }
+  else {
+    std::cout << "Unknown setup command. Available commands:\n";
+    std::cout << "+ [piece] [position] - Add a piece (e.g., '+ K e1' for white king, '+ k e8' for black king)\n";
+    std::cout << "- [position] - Remove a piece (e.g., '- e2')\n";
+    std::cout << "= [color] - Set turn (e.g., '= white' or '= black')\n";
+    std::cout << "done - Exit setup mode\n";
+  }
+  
+  return true;
+}
+
+bool GameController::validateBoard() const {
+  // 1. Each player must have exactly one king
+  bool whiteKingExists = false;
+  bool blackKingExists = false;
+  int whiteKingCount = 0;
+  int blackKingCount = 0;
+  
+  // Count kings and check their positions
+  for (int rank = 0; rank < 8; ++rank) {
+    for (int file = 0; file < 8; ++file) {
+      auto piece = board->pieceAt({file, rank});
+      if (piece) {
+        if (piece->symbol() == 'K') {
+          whiteKingExists = true;
+          whiteKingCount++;
+        }
+        if (piece->symbol() == 'k') {
+          blackKingExists = true;
+          blackKingCount++;
+        }
+      }
+    }
+  }
+  
+  if (!whiteKingExists || !blackKingExists) {
+    std::cout << "Each player must have a king.\n";
+    return false;
+  }
+  
+  if (whiteKingCount > 1) {
+    std::cout << "White cannot have more than one king.\n";
+    return false;
+  }
+  
+  if (blackKingCount > 1) {
+    std::cout << "Black cannot have more than one king.\n";
+    return false;
+  }
+  
+  // 2. No pawns on first or last rank
+  for (int file = 0; file < 8; ++file) {
+    auto piece1 = board->pieceAt({file, 0});
+    auto piece2 = board->pieceAt({file, 7});
+    
+    if ((piece1 && (piece1->symbol() == 'P' || piece1->symbol() == 'p')) ||
+        (piece2 && (piece2->symbol() == 'P' || piece2->symbol() == 'p'))) {
+      std::cout << "Pawns cannot be placed on the first or last rank.\n";
+      return false;
+    }
+  }
+  
+  // 3. Kings cannot be in check in setup mode
+  Colour opponentColour = (board->getCurrentTurn() == Colour::White) ? Colour::Black : Colour::White;
+  
+  if (board->isInCheck(opponentColour)) {
+    std::cout << "The opponent's king cannot be in check at the start of the game.\n";
+    return false;
+  }
+  
+  return true;
+}
+
 void GameController::run() {
   std::string line;
   
   while (std::getline(std::cin, line)) {
-    if (!processCommand(line)) {
-      break;
+    if (setupMode) {
+      if (!processSetupCommand(line)) {
+        break;
+      }
+    } else {
+      if (!processCommand(line)) {
+        break;
+      }
     }
   }
 } 

--- a/GameController.h
+++ b/GameController.h
@@ -14,7 +14,10 @@ public:
 private:
   std::shared_ptr<Board> board;
   bool gameInProgress;
+  bool setupMode;                          // Flag for setup mode
   bool processCommand(const std::string& cmd);
+  bool processSetupCommand(const std::string& cmd); // Process setup mode commands
+  bool validateBoard() const;              // Validate board configuration for setup mode
   Pos parsePos(const std::string& pos);
 };
 


### PR DESCRIPTION
### Setup Mode Feature Implementation

**Summary**
Added complete setup mode functionality to the chess game, allowing users to create custom board configurations.

**Features**

- Enter Setup Mode: Use setup command to enter setup mode
- Place Pieces: + [piece] [position] (e.g., + K e1 for white king)
- Remove Pieces: - [position] (e.g., - e2)
- Set Turn: = [color] (e.g., = white or = black)
- Exit Setup: done command validates the board and exits setup mode

Board Validation
When exiting setup mode, the board is validated to ensure:

- Each player has exactly one king
- No pawns are on the first or last rank
- The opponent's king is not in check

**Implementation Details**

- Added setup mode methods to the Board class
- Added setup mode command processing to the GameController
- Added board validation logic
- Added stalemate detection after setup